### PR TITLE
Stellar base update

### DIFF
--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -95,10 +95,10 @@ def gen_builder(pubkey='', sequence_delta=None):
 
 def submit(builder):
     """Submit a transaction and raise an exception if it fails."""
-    response = builder.submit()
-    if 'status' in response and response['status'] >= 300:
-        raise StellarTransactionFailed(response)
-    return response
+    try:
+        return builder.submit()
+    except stellar_base.exceptions.HorizonError as exception:
+        raise StellarTransactionFailed(exception.message)
 
 
 def submit_transaction_envelope(envelope, seed=None):

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -7,6 +7,7 @@ import stellar_base.asset
 import stellar_base.builder
 import stellar_base.keypair
 import stellar_base.exceptions
+import stellar_base.transaction_envelope
 
 import util.conversion
 import util.logger
@@ -101,8 +102,12 @@ def submit(builder):
         raise StellarTransactionFailed(exception.message)
 
 
-def submit_transaction_envelope(envelope, address=None, seed=None):
+def submit_transaction_envelope(envelope, seed=None):
     """Submit a transaction from an XDR of the envelope. Optionally sign it."""
+    address = None
+    if seed is None:
+        transaction_envelope = stellar_base.transaction_envelope.TransactionEnvelope.from_xdr(envelope)
+        address = transaction_envelope.tx.source
     builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address=address, secret=seed)
     builder.import_from_xdr(envelope)
     if seed:

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -153,7 +153,7 @@ def prepare_escrow(
     # Refund transaction, in case of failed delivery, timelocked.
     builder = gen_builder(escrow_pubkey, sequence_delta=1)
     builder.append_payment_op(launcher_pubkey, total, BUL_TOKEN_CODE, ISSUER)
-    builder.add_time_bounds(type('TimeBound', (), {'minTime': deadline, 'maxTime': 0})())
+    builder.add_time_bounds({'minTime': deadline, 'maxTime': 0})
     add_memo(builder, 'refund')
     refund_envelope = builder.gen_te()
 
@@ -227,7 +227,7 @@ def prepare_relay(relay_pubkey, relayer_pubkey, relayee_pubkey, relayer_stroops,
     builder = gen_builder(relay_pubkey, sequence_delta=1)
     builder.append_change_trust_op(BUL_TOKEN_CODE, ISSUER, '0')
     builder.append_account_merge_op(relayer_pubkey)
-    builder.add_time_bounds(type('TimeBound', (), {'minTime': deadline, 'maxTime': 0})())
+    builder.add_time_bounds({'minTime': deadline, 'maxTime': 0})
     add_memo(builder, 'close relay')
     timelock_merge_envelope = builder.gen_te()
 

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -6,6 +6,7 @@ import stellar_base.address
 import stellar_base.asset
 import stellar_base.builder
 import stellar_base.keypair
+import stellar_base.exceptions
 
 import util.conversion
 import util.logger
@@ -18,6 +19,10 @@ ISSUER_SEED = os.environ.get('PAKET_ISSUER_SEED')
 HORIZON_SERVER = os.environ.get(
     'PAKET_HORIZON_SERVER',
     'https://horizon-testnet.stellar.org' if DEBUG else 'https://horizon.stellar.org')
+
+
+class StellarAccountNotExists(Exception):
+    """A stellar account not exist."""
 
 
 class StellarTransactionFailed(Exception):
@@ -52,10 +57,10 @@ def get_bul_account(pubkey, accept_untrusted=False):
     """Get account details."""
     LOGGER.debug("getting details of %s", pubkey)
     try:
-        details = stellar_base.address.Address(pubkey, horizon=HORIZON_SERVER)
+        details = stellar_base.address.Address(pubkey, horizon_uri=HORIZON_SERVER)
         details.get()
-    except stellar_base.address.AccountNotExistError:
-        raise stellar_base.address.AccountNotExistError("no account found for {}".format(pubkey))
+    except stellar_base.exceptions.HorizonError:
+        raise StellarAccountNotExists("no account found for {}".format(pubkey))
     account = {'sequence': details.sequence, 'signers': details.signers, 'thresholds': details.thresholds}
     for balance in details.balances:
         if balance.get('asset_type') == 'native':
@@ -82,9 +87,9 @@ def gen_builder(pubkey='', sequence_delta=None):
     """Create a builder."""
     if sequence_delta:
         sequence = int(get_bul_account(pubkey, accept_untrusted=True)['sequence']) + sequence_delta
-        builder = stellar_base.builder.Builder(horizon=HORIZON_SERVER, address=pubkey, sequence=sequence)
+        builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address=pubkey, sequence=sequence)
     else:
-        builder = stellar_base.builder.Builder(horizon=HORIZON_SERVER, address=pubkey)
+        builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address=pubkey)
     return builder
 
 
@@ -98,7 +103,7 @@ def submit(builder):
 
 def submit_transaction_envelope(envelope, seed=None):
     """Submit a transaction from an XDR of the envelope. Optionally sign it."""
-    builder = stellar_base.builder.Builder(horizon=HORIZON_SERVER, address='', secret=seed)
+    builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address='', secret=seed)
     builder.import_from_xdr(envelope)
     if seed:
         builder.sign()
@@ -276,7 +281,7 @@ def fund_from_issuer(pubkey, stroop_amount):
         raise NotOnTestnet('funding allowed only on testnet')
     bul_amount = util.conversion.stroops_to_units(stroop_amount)
     LOGGER.warning("funding %s from issuer", pubkey)
-    builder = stellar_base.builder.Builder(horizon=HORIZON_SERVER, secret=ISSUER_SEED)
+    builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, secret=ISSUER_SEED)
     builder.append_payment_op(pubkey, bul_amount, BUL_TOKEN_CODE, ISSUER)
     add_memo(builder, 'fund')
     builder.sign()

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -84,7 +84,7 @@ def add_memo(builder, memo):
     return builder
 
 
-def gen_builder(pubkey='', sequence_delta=None):
+def gen_builder(pubkey, sequence_delta=None):
     """Create a builder."""
     if sequence_delta:
         sequence = int(get_bul_account(pubkey, accept_untrusted=True)['sequence']) + sequence_delta

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -101,9 +101,9 @@ def submit(builder):
         raise StellarTransactionFailed(exception.message)
 
 
-def submit_transaction_envelope(envelope, seed=None):
+def submit_transaction_envelope(envelope, address=None, seed=None):
     """Submit a transaction from an XDR of the envelope. Optionally sign it."""
-    builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address='', secret=seed)
+    builder = stellar_base.builder.Builder(horizon_uri=HORIZON_SERVER, address=address, secret=seed)
     builder.import_from_xdr(envelope)
     if seed:
         builder.sign()

--- a/paket_stellar/__init__.py
+++ b/paket_stellar/__init__.py
@@ -122,7 +122,7 @@ def prepare_trust(from_pubkey, stroop_limit=None):
     """Prepare trust transaction from account."""
     asset_limit = util.conversion.stroops_to_units(stroop_limit) if stroop_limit is not None else None
     builder = gen_builder(from_pubkey)
-    builder.append_trust_op(ISSUER, BUL_TOKEN_CODE, asset_limit)
+    builder.append_change_trust_op(BUL_TOKEN_CODE, ISSUER, asset_limit)
     return builder.gen_te().xdr().decode()
 
 
@@ -165,7 +165,7 @@ def prepare_escrow(
 
     # Merge transaction, to drain the remaining XLM from the account, timelocked.
     builder = gen_builder(escrow_pubkey, sequence_delta=2)
-    builder.append_trust_op(ISSUER, BUL_TOKEN_CODE, 0)
+    builder.append_change_trust_op(BUL_TOKEN_CODE, ISSUER, '0')
     builder.append_account_merge_op(launcher_pubkey)
     add_memo(builder, 'close escrow')
     merge_envelope = builder.gen_te()
@@ -217,7 +217,7 @@ def prepare_relay(relay_pubkey, relayer_pubkey, relayee_pubkey, relayer_stroops,
 
     # Merge transaction, to drain the remaining XLM from the account once relay transaction was submitted.
     builder = gen_builder(relay_pubkey, sequence_delta=2)
-    builder.append_trust_op(ISSUER, BUL_TOKEN_CODE, 0)
+    builder.append_change_trust_op(BUL_TOKEN_CODE, ISSUER, '0')
     builder.append_account_merge_op(relayer_pubkey)
     add_memo(builder, 'close relay')
     sequence_merge_envelope = builder.gen_te()
@@ -225,7 +225,7 @@ def prepare_relay(relay_pubkey, relayer_pubkey, relayee_pubkey, relayer_stroops,
     # Merge transaction, to drain the remaining XLM from the account even if
     # relay transaction was not submitted, but only after deadline has passed.
     builder = gen_builder(relay_pubkey, sequence_delta=1)
-    builder.append_trust_op(ISSUER, BUL_TOKEN_CODE, 0)
+    builder.append_change_trust_op(BUL_TOKEN_CODE, ISSUER, '0')
     builder.append_account_merge_op(relayer_pubkey)
     builder.add_time_bounds(type('TimeBound', (), {'minTime': deadline, 'maxTime': 0})())
     add_memo(builder, 'close relay')

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,11 +1,10 @@
-"""Tests for paket module"""
+"""Tests for paket module."""
 import unittest
-
 
 import paket_stellar
 
 
-def create_and_prepare_account(new_account=False, xlm_starting_balance=50000000, trust_bul=False):
+def setup_account(new_account=False, xlm_starting_balance=50000000, trust_bul=False):
     """Generate new keypair, and optionally create account and set trust."""
     keypair = paket_stellar.get_keypair()
 
@@ -21,44 +20,57 @@ def create_and_prepare_account(new_account=False, xlm_starting_balance=50000000,
     return keypair
 
 
+# pylint: disable=too-many-instance-attributes
 class BasePaketTest(unittest.TestCase):
     """Base class for all paket tests."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.funded_seed = 'SDJGBJZMQ7Z4W3KMSMO2HYEV56DJPOZ7XRR7LJ5X2KW6VKBSLELR7MRQ'
-        self.funded_pubkey = 'GBTWWXA3CDQOSRQ3645B2L4A345CRSKSV6MSBUO4LSHC26ZMNOYFN2YJ'
-        self.valid_untrusted_pubkey = 'GBPRNQA4HU72SJH2ZR3GV4AYCPJEDS64JSA4A62IUW7SYVUKICXXNGWZ'
-        self.invalid_seed = 'GJ1FN8WWJ6FJSS4SKWO5QiJKH'
-        self.invalid_pubkey = 'PGJRLVAEMVWKDSNVSK3FD2LV8DS4FJD6'
+
+        self.invalid_seed = 'invalid seed string'
+        self.invalid_pubkey = 'invalid pubkey string'
+
+        bul_account_keypair = setup_account(new_account=True, trust_bul=True)
+        self.bul_account_seed = bul_account_keypair.seed().decode()
+        self.bul_account_pubkey = bul_account_keypair.address().decode()
+
+        regular_account_keypair = setup_account(new_account=True, xlm_starting_balance=100000000)
+        self.regular_account_seed = regular_account_keypair.seed().decode()
+        self.regular_account_pubkey = regular_account_keypair.address().decode()
+
+        keypair = setup_account()
+        self.seed = keypair.seed().decode()
+        self.address = keypair.address().decode()
+# pylint: enable=too-many-instance-attributes
+
 
 
 class TestGetKeypair(BasePaketTest):
     """Tests for get_keypair function."""
 
     def test_get_from_seed(self):
-        """Test for getting keypair from seed"""
-        keypair = paket_stellar.get_keypair(seed=self.funded_seed)
-        self.assertEqual(keypair.address().decode(), self.funded_pubkey)
+        """Test for getting keypair from seed."""
+        keypair = paket_stellar.get_keypair(seed=self.seed)
+        self.assertEqual(keypair.address().decode(), self.address)
 
     def test_get_from_pubkey(self):
-        """Test for getting keypair from pubkey"""
-        keypair = paket_stellar.get_keypair(pubkey=self.funded_pubkey)
+        """Test for getting keypair from pubkey."""
+        keypair = paket_stellar.get_keypair(pubkey=self.address)
         self.assertIsNone(keypair.signing_key)
 
     def test_get_random(self):
-        """Test for getting random keypair"""
+        """Test for getting random keypair."""
         keypair = paket_stellar.get_keypair()
         self.assertIsNotNone(keypair.signing_key)
         self.assertIsNotNone(keypair.address())
 
     def test_get_from_invalid_seed(self):
-        """Test for getting keypair from invalid seed"""
+        """Test for getting keypair from invalid seed."""
         with self.assertRaises(paket_stellar.stellar_base.exceptions.DecodeError):
             paket_stellar.get_keypair(seed=self.invalid_seed)
 
     def test_get_from_invalid_pubkey(self):
-        """Test for getting from invalid pubkey"""
+        """Test for getting from invalid pubkey."""
         with self.assertRaises(paket_stellar.stellar_base.exceptions.DecodeError):
             paket_stellar.get_keypair(pubkey=self.invalid_pubkey)
 
@@ -67,39 +79,34 @@ class TestGetBulAccount(BasePaketTest):
     """Tests for get_bul_account function."""
 
     def test_get_bul_account(self):
-        """Test for getting bul account"""
-        account = paket_stellar.get_bul_account(pubkey=self.funded_pubkey)
+        """Test for getting bul account."""
+        account = paket_stellar.get_bul_account(pubkey=self.bul_account_pubkey)
         self.assertIn('bul_balance', account)
 
     def test_accept_untrusted(self):
-        """Test for getting bul account that actualy may not have bul balance"""
-        account = paket_stellar.get_bul_account(self.valid_untrusted_pubkey, accept_untrusted=True)
+        """Test for getting bul account that actualy may not have bul balance."""
+        account = paket_stellar.get_bul_account(self.regular_account_pubkey, accept_untrusted=True)
         self.assertNotIn('bul_balance', account)
         with self.assertRaises(paket_stellar.TrustError):
-            paket_stellar.get_bul_account(self.valid_untrusted_pubkey)
-
-    def test_invalid_pubkey(self):
-        """Test for getting bul account from invalid pubkey"""
-        with self.assertRaises(paket_stellar.stellar_base.address.AccountNotExistError):
-            paket_stellar.get_bul_account(self.invalid_pubkey)
+            paket_stellar.get_bul_account(self.regular_account_pubkey)
 
 
 class TestAddMemo(BasePaketTest):
     """Tests for adding memo."""
 
     def test_long_memo(self):
-        """Test for adding memo with length greater than 28 bytes"""
+        """Test for adding memo with length greater than 28 bytes."""
         memo = 'This is very long text that will be truncated to 28 bytes length'
-        builder = paket_stellar.stellar_base.builder.Builder(secret=self.funded_seed)
+        builder = paket_stellar.stellar_base.builder.Builder(secret=self.regular_account_seed)
         builder = paket_stellar.add_memo(builder, memo)
         memo_length = len(builder.memo.text)
         self.assertGreater(memo_length, 0)
         self.assertLessEqual(memo_length, 28)
 
     def test_short_memo(self):
-        """Test for adding memo with length less or equal than 28 bytes"""
+        """Test for adding memo with length less or equal than 28 bytes."""
         memo = 'This is short text of 28 len'
-        builder = paket_stellar.stellar_base.builder.Builder(secret=self.funded_seed)
+        builder = paket_stellar.stellar_base.builder.Builder(secret=self.regular_account_seed)
         builder = paket_stellar.add_memo(builder, memo)
         self.assertEqual(builder.memo.text, memo.encode('utf-8'))
 
@@ -108,21 +115,20 @@ class TestSubmit(BasePaketTest):
     """Tests for submit function."""
 
     def test_submit(self):
-        """Test submitting properly created and signed transaction"""
+        """Test submitting properly created and signed transaction."""
         new_keypair = paket_stellar.get_keypair()
         pubkey = new_keypair.address().decode()
-        builder = paket_stellar.gen_builder(pubkey=self.funded_pubkey)
-        builder.append_create_account_op(destination=pubkey, starting_balance=5)
-        builder.sign(secret=self.funded_seed)
-        result = paket_stellar.submit(builder)
+        create_account_transaction = paket_stellar.prepare_create_account(
+            self.regular_account_pubkey, pubkey, 50000000)
+        result = paket_stellar.submit_transaction_envelope(create_account_transaction, self.regular_account_seed)
         self.assertIn('result_xdr', result)
         self.assertEqual(result['result_xdr'], 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=')
 
     def test_submit_anauth(self):
-        """Test submitting unsigned transaction"""
+        """Test submitting unsigned transaction."""
         new_keypair = paket_stellar.get_keypair()
         pubkey = new_keypair.address().decode()
-        builder = paket_stellar.gen_builder(pubkey=self.funded_pubkey)
+        builder = paket_stellar.gen_builder(pubkey=self.regular_account_pubkey)
         builder.append_create_account_op(destination=pubkey, starting_balance=5)
         with self.assertRaises(paket_stellar.StellarTransactionFailed):
             paket_stellar.submit(builder)
@@ -134,7 +140,7 @@ class TestRelay(BasePaketTest):
     def test_create_relay(self):
         """Test creating relay transactions."""
 
-        relay_keypair = create_and_prepare_account(new_account=True, trust_bul=True)
+        relay_keypair = setup_account(new_account=True, trust_bul=True)
         relayer_keypair = paket_stellar.get_keypair()
         relayee_keypair = paket_stellar.get_keypair()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,7 +27,7 @@ def setup_account(seed, new_account=False, add_trust=False):
     if new_account:
         try:
             account = paket_stellar.get_bul_account(pubkey, accept_untrusted=True)
-        except paket_stellar.stellar_base.address.AccountNotExistError:
+        except paket_stellar.StellarAccountNotExists:
             LOGGER.info("%s not exist and will be created", pubkey)
             create_account_transaction = paket_stellar.prepare_create_account(
                 paket_stellar.ISSUER, pubkey, START_ACCOUNT_BALANCE)

--- a/tests/test.py
+++ b/tests/test.py
@@ -148,7 +148,7 @@ class TestSubmit(BasePaketTest):
         create_account_transaction = paket_stellar.prepare_create_account(
             self.regular_account_pubkey, pubkey, 50000000)
         result = paket_stellar.submit_transaction_envelope(
-            create_account_transaction, self.regular_account_pubkey, self.regular_account_seed)
+            create_account_transaction, self.regular_account_seed)
         self.assertIn('result_xdr', result)
         self.assertEqual(result['result_xdr'], 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=')
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -147,7 +147,8 @@ class TestSubmit(BasePaketTest):
         pubkey = new_keypair.address().decode()
         create_account_transaction = paket_stellar.prepare_create_account(
             self.regular_account_pubkey, pubkey, 50000000)
-        result = paket_stellar.submit_transaction_envelope(create_account_transaction, self.regular_account_seed)
+        result = paket_stellar.submit_transaction_envelope(
+            create_account_transaction, self.regular_account_pubkey, self.regular_account_seed)
         self.assertIn('result_xdr', result)
         self.assertEqual(result['result_xdr'], 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=')
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -93,12 +93,12 @@ class TestGetKeypair(BasePaketTest):
 
     def test_get_from_invalid_seed(self):
         """Test for getting keypair from invalid seed."""
-        with self.assertRaises(paket_stellar.stellar_base.utils.DecodeError):
+        with self.assertRaises(paket_stellar.stellar_base.exceptions.StellarSecretInvalidError):
             paket_stellar.get_keypair(seed=self.invalid_seed)
 
     def test_get_from_invalid_pubkey(self):
         """Test for getting from invalid pubkey."""
-        with self.assertRaises(paket_stellar.stellar_base.utils.DecodeError):
+        with self.assertRaises(paket_stellar.stellar_base.exceptions.StellarAddressInvalidError):
             paket_stellar.get_keypair(pubkey=self.invalid_pubkey)
 
 
@@ -156,7 +156,7 @@ class TestSubmit(BasePaketTest):
         new_keypair = paket_stellar.get_keypair()
         pubkey = new_keypair.address().decode()
         builder = paket_stellar.gen_builder(pubkey=self.regular_account_pubkey)
-        builder.append_create_account_op(destination=pubkey, starting_balance=5)
+        builder.append_create_account_op(destination=pubkey, starting_balance='5')
         with self.assertRaises(paket_stellar.StellarTransactionFailed):
             paket_stellar.submit(builder)
 


### PR DESCRIPTION
According to changes in the new version of stellar_base:
- `horizon` arg renamed to `horizon_uri`
- removed `AccountNotExistError` and added custom `StellarAccountNotExists`
- required using one of stellar secret or stellar address in `Builder`
- used new `append_change_trust_op` instead of deprecated `append_trust_op`
- used dict for creating time bounds